### PR TITLE
Fix random choice of medoids, should not be equal

### DIFF
--- a/kmedoids.py
+++ b/kmedoids.py
@@ -6,7 +6,11 @@ def kMedoids(D, k, tmax=100):
     m, n = D.shape
 
     # randomly initialize an array of k medoid indices
-    M = np.sort(np.random.choice(n, k))
+    # Repeate until all medoids are different
+    while(True):
+        M = np.sort(np.random.choice(n, k))
+        if not np.equal.reduce(M):
+            break
 
     # create a copy of the array of medoid indices
     Mnew = np.copy(M)


### PR DESCRIPTION
It can happens that the random selection of medoids selects multiple times the same data point, I quick fixed this by just repeat the step until all are different. It specially happens with small dataset d and k close to len(d).
