### PR TITLE
Handle duplicate points

### DIFF
--- a/kmedoids.py
+++ b/kmedoids.py
@@ -7,8 +7,30 @@ def kMedoids(D, k, tmax=100):
 
     if k > n:
         raise Exception('too many medoids')
+
+    # find a set of valid initial cluster medoid indices since we
+    # can't seed different clusters with two points at the same location
+    valid_medoid_inds = set(range(n))
+    invalid_medoid_inds = set([])
+    rs,cs = np.where(D==0)
+    # the rows, cols must be shuffled because we will keep the first duplicate below
+    index_shuf = range(len(rs))
+    np.random.shuffle(index_shuf)
+    rs = rs[index_shuf]
+    cs = cs[index_shuf]
+    for r,c in zip(rs,cs):
+        # if there are two points with a distance of 0...
+        # keep the first one for cluster init
+        if r < c and r not in invalid_medoid_inds:
+            invalid_medoid_inds.add(c)
+    valid_medoid_inds = list(valid_medoid_inds - invalid_medoid_inds)
+
+    if k > len(valid_medoid_inds):
+        raise Exception('too many medoids (after removing {} duplicate points)'.format(
+            len(invalid_medoid_inds)))
+
     # randomly initialize an array of k medoid indices
-    M = np.arange(n)
+    M = np.array(valid_medoid_inds)
     np.random.shuffle(M)
     M = np.sort(M[:k])
 


### PR DESCRIPTION
If two points had a distance of 0, they could be placed into two clusters during random initialization. This later led to points being moved to the same cluster which could leave a cluster empty and give the error:
````
/Users/joshsoutherland/got/gates-segmentation/kmedoids.pyc in kMedoids(D, k, tmax)
     30         for kappa in range(k):
     31             J = np.mean(D[np.ix_(C[kappa],C[kappa])],axis=1)
---> 32             j = np.argmin(J)
     33             Mnew[kappa] = C[kappa][j]
     34         np.sort(Mnew)

/Users/joshsoutherland/anaconda/lib/python2.7/site-packages/numpy/core/fromnumeric.pyc in argmin(a, axis, out)
   1017 
   1018     """
-> 1019     return _wrapfunc(a, 'argmin', axis=axis, out=out)
   1020 
   1021 

/Users/joshsoutherland/anaconda/lib/python2.7/site-packages/numpy/core/fromnumeric.pyc in _wrapfunc(obj, method, *args, **kwds)
     55 def _wrapfunc(obj, method, *args, **kwds):
     56     try:
---> 57         return getattr(obj, method)(*args, **kwds)
     58 
     59     # An AttributeError occurs if the object does not have

ValueError: attempt to get argmin of an empty sequence
````


I have added code which detects duplicate points and removes all but one of each duplicate set from the cluster initialization process.  I randomly pick which one is used so that the multiple restart method can still find the optimal cluster (given enough tries).