### PR TITLE
Python3 fix for return of range-function

### DIFF
--- a/kmedoids.py
+++ b/kmedoids.py
@@ -14,7 +14,7 @@ def kMedoids(D, k, tmax=100):
     invalid_medoid_inds = set([])
     rs,cs = np.where(D==0)
     # the rows, cols must be shuffled because we will keep the first duplicate below
-    index_shuf = range(len(rs))
+    index_shuf = list(range(len(rs)))
     np.random.shuffle(index_shuf)
     rs = rs[index_shuf]
     cs = cs[index_shuf]


### PR DESCRIPTION
Python3 returns a lazy sequence object when using the range() function. This fixes this problem by wrapping the return object in a list before assigning to it.

See: https://stackoverflow.com/questions/20484195/typeerror-range-object-does-not-support-item-assignment